### PR TITLE
Use add_url instead of admin_url when linking to app add page

### DIFF
--- a/yawdadmin/templates/admin/app_index.html
+++ b/yawdadmin/templates/admin/app_index.html
@@ -20,7 +20,7 @@
 							<td>{{ model.name }}</td>{% endif %}
 							<td>
 								<div class="pull-right">{% if model.perms.add %}
-									<a href="{{ model.admin_url }}add/" class="btn btn-mini btn-success">
+									<a href="{{ model.add_url }}" class="btn btn-mini btn-success">
 										<i class="icon-plus icon-white"></i>&#xa0;{% trans 'Add' %}
 									</a>{% endif %}{% if model.perms.change %}
 									<a href="{{ model.admin_url }}" class="btn btn-mini btn-info">

--- a/yawdadmin/templates/admin/index.html
+++ b/yawdadmin/templates/admin/index.html
@@ -75,7 +75,7 @@
 											<td>{{ model.name }}</td>{% endif %}
 											<td>
 												<div class="pull-right">{% if model.perms.add %}
-													<a href="{{ model.admin_url }}add/" class="btn btn-mini btn-success">
+													<a href="{{ model.add_url }}" class="btn btn-mini btn-success">
 														<i class="icon-plus icon-white"></i>&#xa0;{% trans 'Add' %}
 													</a>{% endif %}{% if model.perms.change %}
 													<a href="{{ model.admin_url }}" class="btn btn-mini btn-info">


### PR DESCRIPTION
When setting has_change_permission to False for an app the admin_url is not available for the app's model in the template causing a faulty url being used in the admin, django uses add_url instead.
