### PR TITLE
Fixes Unicode encode error

### DIFF
--- a/yawdadmin/templatetags/yawdadmin_tags.py
+++ b/yawdadmin/templatetags/yawdadmin_tags.py
@@ -118,7 +118,7 @@ def inline_items_for_result(inline, result):
         if force_text(result_repr) == '':
             result_repr = mark_safe('&nbsp;')
 
-        ret += format_html('<span{0}>{1}</span>', row_class, result_repr)
+        ret += format_html(u'<span{0}>{1}</span>', row_class, result_repr)
     return ret
 
 


### PR DESCRIPTION
Hi!

Thanks for the great work with yawd-admin, is a great alternative to django-admin. ;)
But well, I'm Brazilian and here we use accents like "ç" and this is not compatible with encodings such as ascii.

See the print below with the word 'preço' (means price):
![unicode_error](https://f.cloud.github.com/assets/154603/1600544/002d7ec6-5373-11e3-9e22-b604f36ea145.png)

To fix this I had to change a line of code.
