### PR TITLE
docs: Fix simple typo, passowrd -> password

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ yawd-admin, a django administration website
 
 yawd-admin now has a live demo at
 `http://yawd-admin.yawd.eu/ <http://yawd-admin.yawd.eu/>`_.
-Use demo / demo as username & passowrd.
+Use demo / demo as username & password.
 
 .. image:: docs/yawd-admin-screenshot.png
 	:align: center

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -95,7 +95,7 @@ Live demo
 
 Alternatively, you can visit the live demo at 
 `http://yawd-admin.yawd.eu/ <http://yawd.eu/open-source-projects/yawd-admin/>`_.
-Use demo / demo as username & passowrd.
+Use demo / demo as username & password.
 
 .. note::
 


### PR DESCRIPTION
There is a small typo in README.rst, docs/installation.rst.

Should read `password` rather than `passowrd`.

